### PR TITLE
[feat] 예약 레디스 대기열 큐 생성

### DIFF
--- a/backend/src/main/java/com/fiiiiive/zippop/global/common/responses/BaseResponseMessage.java
+++ b/backend/src/main/java/com/fiiiiive/zippop/global/common/responses/BaseResponseMessage.java
@@ -164,12 +164,14 @@ public enum BaseResponseMessage {
     ORDERS_SEARCH_ALL_FAIL_INVALID_MEMBER(false, 6028, "해당 거래내역에 접근 권한이 없습니다."),
 
     // ========================================================================================================================
-    // 팝업 예약 9000
+    // 팝업 예약 700
     // 팝업 예약 생성 9000
-    POPUP_RESERVE_CREATE_SUCCESS(true, 9000, "예약 등록에 성공했습니다."),
-    POPUP_RESERVE_CREATE_FAIL_TIME_CLOSED(false, 9001, "해당 시간대는 예약이 마감되었습니다."),
-    POPUP_RESERVE_CREATE_FAIL_INVALID_MEMBER(false, 9002, "기업 회원이 아닌 회원은 예약을 생성할 수 없습니다."),
-    POPUP_RESERVE_CREATE_FAIL_NOT_FOUND(false, 9003, "예약을 생성하려는 팝업스토어를 찾을 수 없습니다."),
+    RESERVE_REGISTER_SUCCESS(true, 7000, "예약 등록에 성공했습니다."),
+    RESERVE_REGISTER_FAIL_INVALID_MEMBER(false, 7001, "해당 팝업 스토어의 관리자가 아닙니다."),
+    RESERVE_REGISTER_FAIL_INVALID_ROLE(false, 7002, "기업 회원이 아닌 회원은 예약을 생성할 수 없습니다."),
+    RESERVE_REGISTER_FAIL_TIME_CLOSED(false, 7003, "해당 시간대는 예약이 마감되었습니다."),
+    RESERVE_REGISTER_FAIL_NOT_FOUND_STORE(false, 7004, "해당 팝업 스토어를 찾을 수 없습니다."),
+    RESERVE_ENROLL_FAIL_NOT_FOUND(false, 9003, "생성된 예약을 찾을 수 없습니다."),
     // 팝업 예약 취소 9100
     POPUP_RESERVE_CANCEL_SUCCESS(true, 9100, "예약 취소에 성공했습니다."),
     POPUP_RESERVE_CANCEL_FAIL(false,  9101, "예약 취소에 실패했습니다."),

--- a/backend/src/main/java/com/fiiiiive/zippop/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/fiiiiive/zippop/global/config/SecurityConfig.java
@@ -60,6 +60,7 @@ public class SecurityConfig {
                         auth
 //                            .requestMatchers("/api/v1/test/**").authenticated()
                             .requestMatchers("/api/v1/auth/get-info").hasAnyAuthority("ROLE_COMPANY", "ROLE_CUSTOMER")
+                            .requestMatchers("/api/v1/reserve/register").hasAuthority("ROLE_COMPANY")
                             .requestMatchers("/api/v1/test/ex01").hasAuthority("ROLE_COMPANY") //RBAC 테스트
                             .anyRequest().permitAll()
         );

--- a/backend/src/main/java/com/fiiiiive/zippop/reserve/controller/ReserveController.java
+++ b/backend/src/main/java/com/fiiiiive/zippop/reserve/controller/ReserveController.java
@@ -5,9 +5,9 @@ import com.fiiiiive.zippop.global.common.exception.BaseException;
 import com.fiiiiive.zippop.global.common.responses.BaseResponse;
 import com.fiiiiive.zippop.global.common.responses.BaseResponseMessage;
 import com.fiiiiive.zippop.global.security.CustomUserDetails;
-import com.fiiiiive.zippop.reserve.service.ReserveService;
 import com.fiiiiive.zippop.reserve.model.dto.CreateReserveReq;
 import com.fiiiiive.zippop.reserve.model.dto.CreateReserveRes;
+import com.fiiiiive.zippop.reserve.service.ReserveService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -28,24 +28,26 @@ public class ReserveController {
     private final ReserveService reserveService;
 
     // 예약 생성
-    @PostMapping("/create")
-    public ResponseEntity<BaseResponse> create(@AuthenticationPrincipal CustomUserDetails customUserDetails, @RequestBody CreateReserveReq dto) throws BaseException {
-        CreateReserveRes response = reserveService.create(customUserDetails, dto);
+    @PostMapping("/register")
+    public ResponseEntity<BaseResponse> register(
+        @AuthenticationPrincipal CustomUserDetails customUserDetails,
+        @RequestBody CreateReserveReq dto) throws BaseException {
+        CreateReserveRes response = reserveService.register(customUserDetails, dto);
         return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.POPUP_RESERVE_CREATE_SUCCESS,response));
     }
 
     // 예약 신청: email -> @AuthenticationPrincipal CustomUserDetails customUserDetails // 테스트 중
     @GetMapping("/enroll")
     public ResponseEntity<BaseResponse> enroll(HttpServletRequest req, HttpServletResponse res,
-                                                String email, @RequestParam Long reserveIdx) throws IOException {
-        String response = reserveService.enroll(req, res, email, reserveIdx);
+                                                String userId, @RequestParam Long reserveIdx) throws IOException {
+        String response = reserveService.enroll(req, res, userId, reserveIdx);
         return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.POPUP_RESERVE_ENROLL_SUCCESS, response));
     }
 
     // 예약 취소: email -> @AuthenticationPrincipal CustomUserDetails customUserDetails // 테스트 중
     @GetMapping("/cancel")
-    public ResponseEntity<BaseResponse> cancel(String email, @RequestParam Long reserveIdx) throws BaseException {
-        String response = reserveService.cancel(email, reserveIdx);
+    public ResponseEntity<BaseResponse> cancel(String userId, @RequestParam Long reserveIdx) throws BaseException {
+        String response = reserveService.cancel(userId, reserveIdx);
         return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.POPUP_RESERVE_CANCEL_SUCCESS, response));
     }
 

--- a/backend/src/main/java/com/fiiiiive/zippop/reserve/model/dto/CreateReserveReq.java
+++ b/backend/src/main/java/com/fiiiiive/zippop/reserve/model/dto/CreateReserveReq.java
@@ -9,6 +9,6 @@ import lombok.*;
 @AllArgsConstructor
 public class CreateReserveReq {
     private Long storeIdx;
-    private Long maxCount;
+    private Long reservePeople;
     private Long expireTime;
 }

--- a/backend/src/main/java/com/fiiiiive/zippop/reserve/model/dto/CreateReserveRes.java
+++ b/backend/src/main/java/com/fiiiiive/zippop/reserve/model/dto/CreateReserveRes.java
@@ -10,7 +10,4 @@ import lombok.*;
 @AllArgsConstructor
 public class CreateReserveRes {
     private Long reserveIdx;
-    private String onDoingUUID;
-    private String waitingUUID;
-    private Long storeIdx;
 }

--- a/backend/src/main/java/com/fiiiiive/zippop/reserve/model/entity/Reserve.java
+++ b/backend/src/main/java/com/fiiiiive/zippop/reserve/model/entity/Reserve.java
@@ -17,9 +17,9 @@ public class Reserve extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long idx;
-    private String onDoingUUID;
+    private String workingUUID;
     private String waitingUUID;
-    private Long maxCount;
+    private Long reservePeople;
     private Long expiredTime;
 
     // ManyToOne


### PR DESCRIPTION
<!-- <풀리퀘스트 템플릿> -->
## 💭 연관 이슈

closed #159 

<br>

## 📌 구현 목표
예약 레디스 대기열 큐 생성
<br>

## ✅ 구현 기능
1. 기업 회원은 레디스 대기열 큐를 생성 / working 큐 와 waiting 큐로 나눠 대기열을 구현
2. 팝업 스토어 예약 정원이 10명일때, 11명이 몰리면 10명은 worker 큐에서 작업 1명은 waiting 큐에서 대기
3. Reserve(예약) 엔티티에 working 큐 wating 큐 정보를 저장
4. 예약 인원을 받으면 Store의 totalpeople - reservePeople

<br>