### PR TITLE
[feat] 예약 레디스 대기열 큐 접속

### DIFF
--- a/backend/src/main/java/com/fiiiiive/zippop/reserve/service/ReserveService.java
+++ b/backend/src/main/java/com/fiiiiive/zippop/reserve/service/ReserveService.java
@@ -62,6 +62,17 @@ public class ReserveService {
         return CreateReserveRes.builder().reserveIdx(reserve.getIdx()).build();
     }
 
+    private void issueWToken(HttpServletResponse res, Long reserveIdx, String userId) {
+        String token = jwtUtil.createReserveToken(reserveIdx, userId);
+        res.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+        Cookie aToken = new Cookie("WTOKEN", token);
+        aToken.setHttpOnly(true);
+        aToken.setSecure(true);
+        aToken.setPath("/");
+        aToken.setMaxAge(60 * 1); // 1분간 유효
+        res.addCookie(aToken);
+    }
+
     public String enroll(HttpServletResponse res, CustomUserDetails customUserDetails, Long reserveIdx) throws BaseException {
         // 1. 예외: 기업 회원이 아닐 때, 스토어 조회 안될 때, 스토어의 이메일과 인증된 사용자의 이메일이 다를 때
         Reserve reserve = reserveRepository.findById(reserveIdx).orElseThrow(
@@ -74,30 +85,33 @@ public class ReserveService {
         String workingUUID = reserve.getWorkingUUID();
         String waitingUUID = reserve.getWaitingUUID();
         String userId = customUserDetails.getUserId();
+
+        // 예약 접속 큐의 현재 크기 및 사용자의 순서 조회
         Long currentOrder = redisUtil.getOrder(workingUUID,userId);
-        // if: 예약 접속 큐 등록 및 토큰 발급: 만약 예약자수보다 redis의 크기값이 적거나, 현재 working 큐에 있을때(사이트 재접속)
-        if(reserve.getReservePeople() > redisUtil.getSize(workingUUID) || currentOrder != null){
-            // 예약 redis의 자리가 있을때
-            if(redisUtil.getOrder(workingUUID, userId) == null){
-                redisUtil.save(workingUUID, userId, System.currentTimeMillis());
-            }
-             // 예약 페이지에 접근할 수 있는 accessToken 만들어줌
-            String token = jwtUtil.createReserveToken(reserveIdx, userId);
-            res.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
-            Cookie aToken = new Cookie("WTOKEN", token);
-            aToken.setHttpOnly(true);
-            aToken.setSecure(true);
-            aToken.setPath("/");
-            aToken.setMaxAge(60 * 1);
-            res.addCookie(aToken);
-            // 예약 굿즈 구매 사이트로 이동 리다이렉션? 토큰이 없는 유저가 예약굿즈 구매 접근시 뒤로 보내야됨
-            long rank = redisUtil.getOrder(workingUUID, userId) + 1L;
-            return "팝업 스토어 예약 굿즈 페이지로 이동합니다 -> 접속 번호" + rank;
-        }  else { // 예약 redis가 꽉차면 대기 redis로 이동
-            redisUtil.save(waitingUUID, userId, System.currentTimeMillis());
-            long rank = redisUtil.getOrder(waitingUUID, userId) + 1L;
-            return "예약 대기: "+rank;
+        Long workingQueueSize = redisUtil.getSize(workingUUID);
+        // 예약 접속 큐에 사용자가 이미 있는 경우 -> 사이트 재접속
+
+        if (currentOrder != null) {
+            // 이미 등록되어 있으므로 토큰을 발급합니다.
+            issueWToken(res, reserveIdx, userId);
+            long rank = currentOrder + 1; // 0부터 시작하므로 +1 해서 순위를 반환
+            return "팝업 스토어 예약 굿즈 페이지로 이동합니다 -> 접속 번호 " + rank;
         }
+        // 예약 접속 큐에 자리가 있는 경우 (현재 예약자 수보다 큐의 크기가 작은 경우)
+        if (workingQueueSize < reserve.getReservePeople()) {
+            // 새로운 사용자 등록
+            redisUtil.save(workingUUID, userId, System.currentTimeMillis());
+
+            issueWToken(res, reserveIdx, userId);
+
+            long rank = redisUtil.getOrder(workingUUID, userId) + 1;
+            return "팝업 스토어 예약 굿즈 페이지로 이동합니다 -> 접속 번호 " + rank;
+        }
+
+        // 예약 접속 큐가 꽉 찬 경우 -> 대기 큐에 추가
+        redisUtil.save(waitingUUID, userId, System.currentTimeMillis());
+        long rank = redisUtil.getOrder(waitingUUID, userId) + 1;
+        return "예약 대기: " + rank;
     }
 
     public String cancel(String userId, Long reserveIdx) throws BaseException {


### PR DESCRIPTION
<!-- <풀리퀘스트 템플릿> -->
## 💭 연관 이슈

closed #161 

<br>

## 📌 구현 목표
예약 레디스 대기열 큐 접속
<br>

## ✅ 구현 기능
 1. 예약 접속 큐 등록 및 토큰 발급: 만약 예약자수보다 redis의 크기값이 적거나, 현재 working 큐에 있을때(사이트 재접속)
 2. 토큰 발급 : 예약 굿즈 구매 페이지에 대해 접근을 제어
 3. 토큰이 발급된 예약자는 예약취소 버튼을 누르기 전까지 순서를 보장받음
 4. 홈페이지 새로고침 시에는 사이트 재접속을 지원
 5. 홈페이지에서 뒤로가기 이벤트가 발생하면 자동으로 예약 취소를 수행
<br>